### PR TITLE
Fix timestamp parsing

### DIFF
--- a/gantry/models/job.py
+++ b/gantry/models/job.py
@@ -1,5 +1,6 @@
 import re
-from datetime import datetime
+
+from gantry.util.time import webhook_timestamp
 
 
 class Job:
@@ -17,9 +18,10 @@ class Job:
         self.gl_id = gl_id
         # handle jobs that haven't started or finished
         if start:
-            self.start = datetime.fromisoformat(start).timestamp()
+            self.start = webhook_timestamp(start)
         if end:
-            self.end = datetime.fromisoformat(end).timestamp()
+            self.end = webhook_timestamp(end)
+
         self.ref = ref
 
     @property

--- a/gantry/tests/defs/collection.py
+++ b/gantry/tests/defs/collection.py
@@ -12,8 +12,8 @@ VALID_JOB = {
     "build_status": "success",
     "build_name": "gmsh@4.8.4 /jcchwaj %gcc@11.4.0 arch=linux-ubuntu20.04-x86_64_v3 E4S",
     "build_id": 9892514,  # not used in testing unless it already exists in the db
-    "build_started_at": "2024-01-24T17:24:06.000Z",
-    "build_finished_at": "2024-01-24T17:47:00.000Z",
+    "build_started_at": "2024-01-24 17:24:06 UTC",
+    "build_finished_at": "2024-01-24 17:47:00 UTC",
     "ref": "pr42264_bugfix/mathomp4/hdf5-appleclang15",
     "runner": {"description": "aws"},
 }

--- a/gantry/util/time.py
+++ b/gantry/util/time.py
@@ -1,0 +1,15 @@
+import datetime
+
+
+def webhook_timestamp(dt: str) -> float:
+    """Converts a gitlab webhook datetime to a unix timestamp."""
+    # gitlab sends dates in 2021-02-23 02:41:37 UTC format
+    # documentation says they use iso 8601, but they don't consistently apply it
+    # https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events
+    GITLAB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S %Z"
+    # strptime doesn't tag with timezone by default
+    return (
+        datetime.datetime.strptime(dt, GITLAB_DATETIME_FORMAT)
+        .replace(tzinfo=datetime.timezone.utc)
+        .timestamp()
+    )


### PR DESCRIPTION
Gitlab's webhook API falsely represents that it returns timestamps in ISO8601 format, which broke our parser.

We now parse timestamps in the format Gitlab sends in webhooks (`2024-05-30 07:01:39 UTC`), which is inconsistent with its [docs](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events) and the job API.
