### PR TITLE
clarify prediction docs

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -37,11 +37,3 @@ To illustrate the problem, let's go through some usage numbers (across all build
 - max/request = 2.69
 
 There is a lot of misallocation going on here. As was said above, limits are not enforced, so request is the closest we're going to get to a useful comparison of usage. Bottom line, we are using a lot less memory than we request, and more CPU than we ask for.
-
-## Cost per job
-
-Work is being performed to determine the best way to model the cost per job and node. 
-
-**Notes**:
-- waste needs to be quantified in the cost per job
-- instance type should be controlled for, as we don't want the number of cores to be the variable in the cost function, since the performance can vary drastically

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -40,40 +40,8 @@ We've done some analysis to determine the best predictors of resource usage. Bec
 
 Variants are always included as a predictor.
 
+Microarchitecture is not used as a parameter in the model because it is not a strong predictor of resource usage. Additionally, we avoid limiting the sample size by not filtering past results on architecture, allowing for more accurate predictions.
+
 Our analysis shows that the optimal number of builds to include in the prediction function is five, though we prefer four if the program will drop down to the next set in the list.
 
 We do not use PR builds as part of the training data, as they are potential vectors for manipulation and can be error prone. The predictions will apply to both PR and develop jobs.
-
-## Plan
-
-1. In the pilot phase, we will only be implementing predictions for requests, and ensuring that they will only increase compared to current allocations.
-
-2. If we see success in the pilot, we'll implement functionality which retries jobs with higher memory allocations if they've been shown to fail due to OOM kills.
-
-3. Then, we will "drop the floor" and allow the predictor to allocate less memory than the package is used to. At this step, requests will be fully implemented.
-
-4. Limits for CPU and memory will be implemented.
-
-5. Next, we want to introduce some experimentation in the system and perform a [scaling study](#fuzzing).
-
-6. Design a scheduler that decides which instance type a job should be placed on based on cost and expected usage and runtime.
-
-## Evaluation
-
-The success of our predictions can be evaluated against a number of factors:
-
-- How much cheaper is the job?
-- Closeness of request or limit to actual usage
-- Jobs being killed due to resource contention
-- Error distribution of prediction
-- How much waste is there per build type?
-
-## Fuzzing
-
-10-15% of builds would be randomly selected to have their CPU limit modified up or down. This would happen a few times for the build, and see if we can find an optimal efficiency for the job, which would be used to define future CPU limit and number of build jobs.
-
-We're essentially adding variance to the resource allocation and seeing how the system responds.
-
-This is a strong scaling study, and the plot of interest is the efficiency curve.
-
-Efficiency defined as cores/build time.


### PR DESCRIPTION
instead of storing plans in docs, better organized in GH issues