### PR TITLE
Validate status of build job using stage rather than name

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,7 +19,7 @@ The payload should be include the following fields at a minimum (Gitlab will inc
 ```
 {
     "build_status": str,
-    "build_name": str,
+    "build_stage": str,
     "build_id": int,
     "build_started_at": str,
     "build_finished_at": str,

--- a/gantry/models/job.py
+++ b/gantry/models/job.py
@@ -1,5 +1,3 @@
-import re
-
 from gantry.util.time import webhook_timestamp
 
 
@@ -7,14 +5,12 @@ class Job:
     def __init__(
         self,
         status: str,
-        name: str,
         gl_id: int,
         start: str,
         end: str,
         ref: str,
     ):
         self.status = status
-        self.name = name
         self.gl_id = gl_id
         # handle jobs that haven't started or finished
         if start:
@@ -30,16 +26,3 @@ class Job:
         # prometheus is not guaranteed to have data at the exact start and end times
         # instead of creating an arbitrary buffer, ask for data in the middle of the job
         return (self.start + self.end) / 2
-
-    @property
-    def valid_build_name(self) -> bool:
-        """validates the job name."""
-
-        # example: plumed@2.9.0 /i4u7p6u %gcc@11.4.0
-        # arch=linux-ubuntu20.04-neoverse_v1 E4S ARM Neoverse V1
-        job_name_pattern = re.compile(
-            r"([^/ ]+)@([^/ ]+) /([^%]+) %([^ ]+) ([^ ]+) (.+)"
-        )
-        job_name_match = job_name_pattern.match(self.name)
-        # groups: 1: name, 2: version, 3: hash, 4: compiler, 5: arch, 6: stack
-        return bool(job_name_match)

--- a/gantry/tests/defs/collection.py
+++ b/gantry/tests/defs/collection.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 # fmt: off
 
-INVALID_JOB_NAME = "invalid job name"
+INVALID_STAGE = "stage-generate"
 # uo runners are not supported
 INVALID_RUNNER = {"description": "uo-blabla1821"}
 INVALID_JOB_STATUS = "failure"
@@ -10,7 +10,7 @@ VALID_JOB_LOG = "some log"
 
 VALID_JOB = {
     "build_status": "success",
-    "build_name": "gmsh@4.8.4 /jcchwaj %gcc@11.4.0 arch=linux-ubuntu20.04-x86_64_v3 E4S",
+    "build_stage": "stage-1",
     "build_id": 9892514,  # not used in testing unless it already exists in the db
     "build_started_at": "2024-01-24 17:24:06 UTC",
     "build_finished_at": "2024-01-24 17:47:00 UTC",

--- a/gantry/tests/test_collection.py
+++ b/gantry/tests/test_collection.py
@@ -47,7 +47,7 @@ async def prometheus(mocker):
     "key, value",
     [
         ("build_status", defs.INVALID_JOB_STATUS),
-        ("build_name", defs.INVALID_JOB_NAME),
+        ("build_stage", defs.INVALID_STAGE),
         ("runner", defs.INVALID_RUNNER),
     ],
 )


### PR DESCRIPTION
Use stage instead of job name, which has the potential to change format and silently break collection of webhooks without us knowing. Also cleans up the job model a bit.

credit to `spack-infrastructure/analytics/analytics/core/views.py` for the idea