### PR TITLE
Fix UO runner detection

### DIFF
--- a/gantry/routes/collection.py
+++ b/gantry/routes/collection.py
@@ -50,7 +50,7 @@ async def fetch_job(
         # some jobs don't have runners..?
         or payload["runner"] is None
         # uo runners are not in Prometheus
-        or payload["runner"]["description"].startswith("uo")
+        or payload["runner"]["description"].strip().startswith("uo")
         # job already in the database
         or await db.job_exists(db_conn, job.gl_id)
     ):


### PR DESCRIPTION
Unfortunately, the beginning of UO runners aren't guaranteed to contain non-whitespace chars. See: https://gitlab.spack.io/api/v4/projects/2/jobs/12307799

```
"runner":{"id":57407,"description":"    uo-grover-protected-small-medium-0"