### PR TITLE
Update spec format to include arch

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@ Given a spec, the API will calculate the optimal resource allocation for the job
 The spec sent to the endpoint should have the following format:
 
 ```
-pkg_name@pkg_version +variant1+variant2%compiler@compiler_version
+pkg_name@pkg_version +variant1+variant2 arch=arch%compiler@compiler_version
 ```
 
 Be sure that the string is URL-encoded. For instance, the `urllib.parse.quote` method will ensure the proper format. Without it, the allocation algorithm may return inaccurate results.

--- a/gantry/tests/defs/prediction.py
+++ b/gantry/tests/defs/prediction.py
@@ -4,18 +4,18 @@
 from gantry.util.spec import parse_alloc_spec
 
 NORMAL_BUILD = parse_alloc_spec(
-    "py-torch@2.2.1 ~caffe2+cuda+cudnn~debug+distributed+fbgemm+gloo+kineto~magma~metal+mkldnn+mpi~nccl+nnpack+numa+numpy+onnx_ml+openmp+qnnpack~rocm+tensorpipe~test+valgrind+xnnpack build_system=python_pip cuda_arch=80%gcc@11.4.0"
+    "py-torch@2.2.1 ~caffe2+cuda+cudnn~debug+distributed+fbgemm+gloo+kineto~magma~metal+mkldnn+mpi~nccl+nnpack+numa+numpy+onnx_ml+openmp+qnnpack~rocm+tensorpipe~test+valgrind+xnnpack build_system=python_pip cuda_arch=80 arch=x86_64%gcc@11.4.0"
 )
 
 # everything in NORMAL_BUILD["package"]["variants"] except removing build_system=python_pip
 # in order to test the expensive variants filter
 EXPENSIVE_VARIANT_BUILD = parse_alloc_spec(
-    "py-torch@2.2.1 ~caffe2+cuda+cudnn~debug+distributed+fbgemm+gloo+kineto~magma~metal+mkldnn+mpi~nccl+nnpack+numa+numpy+onnx_ml+openmp+qnnpack~rocm+tensorpipe~test+valgrind+xnnpack cuda_arch=80%gcc@11.4.0"
+    "py-torch@2.2.1 ~caffe2+cuda+cudnn~debug+distributed+fbgemm+gloo+kineto~magma~metal+mkldnn+mpi~nccl+nnpack+numa+numpy+onnx_ml+openmp+qnnpack~rocm+tensorpipe~test+valgrind+xnnpack cuda_arch=80 arch=x86_64%gcc@11.4.0"
 )
 
 # no variants should match this, so we expect the default prediction
 BAD_VARIANT_BUILD = parse_alloc_spec(
-    "py-torch@2.2.1 +no~expensive~variants+match%gcc@11.4.0"
+    "py-torch@2.2.1 +no~expensive~variants+match arch=x86_64%gcc@11.4.0"
 )
 
 # calculated by running the baseline prediction algorithm on the sample data in gantry/tests/sql/insert_prediction.sql

--- a/gantry/tests/test_prediction.py
+++ b/gantry/tests/test_prediction.py
@@ -76,13 +76,16 @@ async def test_empty_sample(db_conn):
 # Test validate_payload
 def test_valid_spec():
     """Tests that a valid spec is parsed correctly."""
-    assert parse_alloc_spec("emacs@29.2-test +json+native+treesitter%gcc@12.3.0") == {
+    assert parse_alloc_spec(
+        "emacs@29.2-test +json+native+treesitter arch=x86_64%gcc@12.3.0"
+    ) == {
         "pkg_name": "emacs",
         "pkg_version": "29.2-test",
         "pkg_variants": '{"json": true, "native": true, "treesitter": true}',
         "pkg_variants_dict": {"json": True, "native": True, "treesitter": True},
         "compiler_name": "gcc",
         "compiler_version": "12.3.0",
+        "arch": "x86_64",
     }
 
 

--- a/gantry/util/spec.py
+++ b/gantry/util/spec.py
@@ -43,6 +43,7 @@ def parse_alloc_spec(spec: str) -> dict:
     - pkg_variants_dict: dict
     - compiler: str
     - compiler_version: str
+    - arch: str
 
     Returns an empty dict if the spec is invalid.
 
@@ -52,7 +53,7 @@ def parse_alloc_spec(spec: str) -> dict:
 
     # example: emacs@29.2 +json+native+treesitter arch=x86_64%gcc@12.3.0
     # this regex accommodates versions made up of any non-space characters
-    spec_pattern = re.compile(r"(.+?)@(\S+)\s+(.+?)\s+arch=(\S+)%([\w-]+)@(\S+)")
+    spec_pattern = re.compile(r"(.+?)@(\S+)\s+(.+?)\s+aech=(\S+)%([\w-]+)@(\S+)")
 
     match = spec_pattern.match(spec)
     if not match:

--- a/gantry/util/spec.py
+++ b/gantry/util/spec.py
@@ -53,7 +53,7 @@ def parse_alloc_spec(spec: str) -> dict:
 
     # example: emacs@29.2 +json+native+treesitter arch=x86_64%gcc@12.3.0
     # this regex accommodates versions made up of any non-space characters
-    spec_pattern = re.compile(r"(.+?)@(\S+)\s+(.+?)\s+aech=(\S+)%([\w-]+)@(\S+)")
+    spec_pattern = re.compile(r"(.+?)@(\S+)\s+(.+?)\s+arch=(\S+)%([\w-]+)@(\S+)")
 
     match = spec_pattern.match(spec)
     if not match:

--- a/gantry/util/spec.py
+++ b/gantry/util/spec.py
@@ -50,9 +50,9 @@ def parse_alloc_spec(spec: str) -> dict:
     for the client.
     """
 
-    # example: emacs@29.2 +json+native+treesitter%gcc@12.3.0
+    # example: emacs@29.2 +json+native+treesitter arch=x86_64%gcc@12.3.0
     # this regex accommodates versions made up of any non-space characters
-    spec_pattern = re.compile(r"(.+?)@(\S+)\s+(.+?)%([\w-]+)@(\S+)")
+    spec_pattern = re.compile(r"(.+?)@(\S+)\s+(.+?)\s+arch=(\S+)%([\w-]+)@(\S+)")
 
     match = spec_pattern.match(spec)
     if not match:
@@ -64,6 +64,7 @@ def parse_alloc_spec(spec: str) -> dict:
         pkg_name,
         pkg_version,
         pkg_variants,
+        arch,
         compiler_name,
         compiler_version,
     ) = match.groups()
@@ -83,6 +84,7 @@ def parse_alloc_spec(spec: str) -> dict:
         "pkg_variants_dict": pkg_variants_dict,
         "compiler_name": compiler_name,
         "compiler_version": compiler_version,
+        "arch": arch,
     }
 
     return spec_dict

--- a/gantry/views.py
+++ b/gantry/views.py
@@ -46,7 +46,7 @@ async def allocation(request: web.Request) -> web.Response:
     that set resource allocations based on historical data.
 
     acceptable spec format:
-    pkg_name@pkg_version +variant1+variant2%compiler@compiler_version
+    pkg_name@pkg_version +variant1+variant2%compiler arch=arch@compiler_version
     NOTE: there must be a space between the package version and the variants
 
     returns:


### PR DESCRIPTION
pulled from #4 

we require increased granularity to link past jobs to future retried jobs, so this PR adds `arch` as an required parameter when requesting an allocation.

tested against latest version of https://github.com/spack/spack/pull/41622