### PR TITLE
Gracefully handle HTTP errors

### DIFF
--- a/gantry/clients/gitlab.py
+++ b/gantry/clients/gitlab.py
@@ -17,7 +17,7 @@ class GitlabClient:
         returns: the response from Gitlab in the specified format
         """
 
-        async with aiohttp.ClientSession(raise_for_status=True) as session:
+        async with aiohttp.ClientSession() as session:
             async with session.get(url, headers=self.headers) as resp:
                 if response_type == "json":
                     return await resp.json()

--- a/gantry/clients/prometheus/prometheus.py
+++ b/gantry/clients/prometheus/prometheus.py
@@ -68,17 +68,17 @@ class PrometheusClient:
 
     async def _query(self, url: str) -> list:
         """Query Prometheus with a query string"""
-        async with aiohttp.ClientSession(raise_for_status=True) as session:
+        async with aiohttp.ClientSession() as session:
             # submit cookie with request
             async with session.get(url, cookies=self.cookies) as resp:
                 try:
                     return await resp.json()
                 except aiohttp.ContentTypeError:
-                    logger.error(
-                        """Prometheus query failed with unexpected response.
-                        The cookie may have expired."""
+                    # this will get caught in collection.py and fetch_job won't continue
+                    raise aiohttp.ClientError(
+                        """Prometheus query failed with unexpected
+                        response, cookie may have expired."""
                     )
-                    return {}
 
     def prettify_res(self, response: dict) -> list:
         """Process Prometheus response into a list of dicts with {label: value}"""


### PR DESCRIPTION
closes #111

We were setting `raise_for_status` and not handling exceptions raised by aiohttp, which clogged up the logs with stack traces and env variables.

I did not add an automatic retry to HTTP requests because the issues in the cluster are not necessarily going to solve themselves in the scope of 5 retried requests.

I'll be dealing with the gitlab 500 errors in a different PR.